### PR TITLE
Fix data.overheid.nl links on Corona page.

### DIFF
--- a/_data/corona.json
+++ b/_data/corona.json
@@ -3,25 +3,25 @@
         "nl":[
             {
                 "title": "API's van developer.overheid.nl",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "Overzicht van alle API's momenteel beschikbaar vanuit Nederlandse overheden.",
                 "link_text": "Bekijk deze data"
             },
             {
                 "title": "RIVM data Code For NL",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "API ontsluiting van de RIVM besmettingsdata.",
                 "link_text": "Bekijk deze data"
             },
             {
                 "title": "Corona Pioniers VPRO",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "Data en API voor maatschappelijke corona initiatieven.",
                 "link_text": "Bekijk deze data"
             },
             {
                 "title": "Open Stad API",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "Ontsluiting data en source open stad gemeente Amsterdam",
                 "link_text": "Bekijk deze data"
             }
@@ -29,25 +29,25 @@
         "en":[
             {
                 "title": "API's of developer.overheid.nl",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "Overview of all APIs currently available from Dutch governments.",
                 "link_text": "View this data"
             },
             {
                 "title": "RIVM data Code For NL",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "API disclosure of the RIVM contamination data.",
                 "link_text": "View this data"
             },
             {
                 "title": "Corona Pioniers VPRO",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "Data and API for social corona initiatives.",
                 "link_text": "View this data"
             },
             {
                 "title": "Open City API",
-                "link": "data.overheid.nl",
+                "link": "https://data.overheid.nl",
                 "tagline": "Disclosure of data and source of open city of Amsterdam",
                 "link_text": "View this data"
             }


### PR DESCRIPTION
This fixes the data links on https://www.codefor.nl/corona.

These links currently point to https://www.codefor.nl/data.overheid.nl because of the missing protocol prefix.